### PR TITLE
Changes over to loading pages from github

### DIFF
--- a/src/plugins/dnd-content.js
+++ b/src/plugins/dnd-content.js
@@ -1,19 +1,44 @@
 import YAML from "yaml";
 import axios from "axios";
 import { Octokit } from "@octokit/rest";
-let octokit;
 
-if (process.server) {
-  octokit = new Octokit({
-    auth: process.env["GITHUB_TOKEN"],
-  });
-} else {
-  octokit = new Octokit();
+// TODO support branches
+class GitHubContent {
+  constructor(owner, repo, path, token = null) {
+    this.owner = owner;
+    this.repo = repo;
+    this.path = path;
+    this.octokit = new Octokit({ auth: token });
+  }
+
+  async loadAll(collection) {
+    const response = await this.octokit.repos.getContent({
+      owner: this.owner,
+      repo: this.repo,
+      path: `${this.path}/${collection}`,
+    });
+    logRateLimit(response);
+    return Promise.all(
+      response.data.map(async ({ name, download_url }) => {
+        const response = await axios.get(download_url);
+        const data = YAML.parse(response.data);
+        return {
+          ...data,
+          path: `${collection}/${name.substring(0, name.lastIndexOf("."))}`,
+        };
+      })
+    );
+  }
+
+  async loadSingle(collection, name) {
+    const url = `https://raw.githubusercontent.com/${this.owner}/${this.repo}/master/${this.path}/${collection}/${name}.yaml`;
+    const response = await axios.get(url);
+    return {
+      ...YAML.parse(response.data),
+      path: `${collection}/${name}`,
+    };
+  }
 }
-
-// TODO make these configuable and support multiple repos
-const owner = "mdaffin";
-const repo = "dnd-deck";
 
 const logRateLimit = (response) => {
   const rateLimit = response.headers["x-ratelimit-remaining"];
@@ -27,50 +52,23 @@ const logRateLimit = (response) => {
   );
 };
 
-const loadAll = (path, collection) => async () => {
-  const response = await octokit.repos.getContent({
-    owner,
-    repo,
-    path: `${path}/${collection}`,
-  });
-  logRateLimit(response);
-  return Promise.all(
-    response.data.map(async ({ name, download_url }) => {
-      const response = await axios.get(download_url);
-      const data = YAML.parse(response.data);
-      return {
-        ...data,
-        path: `${collection}/${name.substring(0, name.lastIndexOf("."))}`,
-      };
-    })
-  );
-};
-
-const loadSingle = (path, collection) => async (name) => {
-  const download_url = `${path}/${collection}/${name}.yaml`;
-  console.log(`download_URL: ${download_url}`);
-  const response = await axios.get(download_url);
-  const data = YAML.parse(response.data);
-  return {
-    ...data,
-    path: `${collection}/${name}`,
-  };
-};
-
 export default ({ app }) => {
-  app.races = loadAll("src/content", "races");
-  app.race = loadSingle(
-    `https://raw.githubusercontent.com/${owner}/${repo}/master/src/content`,
-    "races"
-  );
-  app.characters = loadAll("src/content", "characters");
-  app.character = loadSingle(
-    `https://raw.githubusercontent.com/${owner}/${repo}/master/src/content`,
-    "characters"
-  );
-  app.charClasses = loadAll("src/content", "classes");
-  app.charClass = loadSingle(
-    `https://raw.githubusercontent.com/${owner}/${repo}/master/src/content`,
-    "classes"
-  );
+  // TODO make these configuable and support multiple repos
+  const owner = "mdaffin";
+  const repo = "dnd-deck";
+  const path = "src/content";
+
+  let token;
+  if (process.server) {
+    token = process.env["GITHUB_TOKEN"];
+  }
+
+  const githubContent = new GitHubContent(owner, repo, path, token);
+  app.races = () => githubContent.loadAll("races");
+  app.characters = () => githubContent.loadAll("characters");
+  app.charClasses = () => githubContent.loadAll("classes");
+
+  app.race = (name) => githubContent.loadSingle("races", name);
+  app.character = (name) => githubContent.loadSingle("characters", name);
+  app.charClass = (name) => githubContent.loadSingle("classes", name);
 };


### PR DESCRIPTION
This allows for us to refactor to load content from other github repos in the same way as loading main content. There is a caviate though - you can only make 60 requests to the API every hour, luckly raw content does not count so this only happens when you load the index which uses 3 requests to get the list of char, races and characters.